### PR TITLE
ssl support improvements

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,5 +24,4 @@
   :repl-options {:init (do (require 'spyscope.core)
                            (use 'clj-puppetdb.testutils.repl))}
   :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.5"]
-                                  [spyscope "0.1.5" :exclusions [clj-time]]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 "1.1.0"]]}})
+                                  [spyscope "0.1.5" :exclusions [clj-time]]]}})

--- a/src/clj_puppetdb/http.clj
+++ b/src/clj_puppetdb/http.clj
@@ -5,29 +5,43 @@
             [clj-puppetdb.schema :refer [Client]]
             [clj-puppetdb.util :refer [file?]]
             [clj-puppetdb.vcr :refer [vcr-get]]
-            [puppetlabs.certificate-authority.core :as ssl]
+            [puppetlabs.ssl-utils.core :as ssl]
             [puppetlabs.http.client.sync :as http]
             [schema.core :as s])
-  (:import [java.io IOException]
+  (:import [java.io IOException File]
+           [javax.net.ssl SSLContext]
            [com.fasterxml.jackson.core JsonParseException]))
 
 ;; TODO:
 ;;   - Validate schema for GET params. The GetParams schema
 ;;     exists, but needs work before it can be used.
 
+
+(def cert-keys
+  "The keys to the configuration map specifying the certificates/private key
+  needed for creating the SSL context.
+  Warning: the order of the keys must match that expected by the
+  `puppetlabs.ssl-utils.core/pems->ssl-context` function."
+  [:ssl-cert :ssl-key :ssl-ca-cert])
+
 (defn- make-https-client
-  [^String host {:keys [ssl-context ssl-ca-cert ssl-cert ssl-key vcr-dir] :as opts}]
-  {:pre  [(or ssl-context
+  [^String host {:keys [ssl-context vcr-dir] :as opts}]
+  {:pre  [(.startsWith host "https://")
+          (or (and ssl-context (or (instance? SSLContext ssl-context)
+                                   (throw (IllegalArgumentException.
+                                            (str "The ssl-context is expected to be an instance of "
+                                                 (-> SSLContext .getName)
+                                                 " but is of class "
+                                                 (-> ssl-context .getClass .getName))))))
               (every? #(or (file? (get opts %))
                            (throw (IllegalArgumentException.
-                             (format "The following file does not exist: %s=%s" % (get opts %)))))
-                      [:ssl-ca-cert :ssl-cert :ssl-key]))
-          (.startsWith host "https://")]
+                                    (str "The following file does not exist: " (name %) \= (get opts %)))))
+                      cert-keys))]
    :post [(s/validate Client %)]}
   {:host host
    :opts {:ssl-context (if ssl-context
                          ssl-context
-                         (ssl/pems->ssl-context ssl-cert ssl-key ssl-ca-cert))
+                         (apply ssl/pems->ssl-context (map #(->> % (get opts) File.) cert-keys)))
           :vcr-dir     vcr-dir}})
 
 (defn- make-http-client

--- a/src/clj_puppetdb/util.clj
+++ b/src/clj_puppetdb/util.clj
@@ -1,9 +1,8 @@
 (ns clj-puppetdb.util
-  (:import [java.io File]
-           [java.net URL]))
+  (:import [java.io File]))
 
 (defn file?
-  [^URL f]
+  [^String f]
   (if (nil? f)
     false
-    (-> f .toURI File. .isFile)))
+    (-> f File. .isFile)))

--- a/test/clj_puppetdb/core_test.clj
+++ b/test/clj_puppetdb/core_test.clj
@@ -1,11 +1,6 @@
 (ns clj-puppetdb.core-test
   (:require [clojure.test :refer :all]
-            [clj-puppetdb.core :refer :all]
-            [puppetlabs.certificate-authority.core :as ssl])
-  (:import [java.io File]))
-
-(defn- to-url [file]
-  (-> file File. .toURI .toURL))
+            [clj-puppetdb.core :refer :all]))
 
 (deftest connect-test
   (testing "Should create a connection with http://localhost:8080 with no additional arguments"
@@ -14,19 +9,19 @@
   (testing "Should create a connection with http://localhost:8080 and VCR enabled"
     (let [conn (connect "http://localhost:8080" {:vcr-dir "/temp"})]
       (is (= conn {:host "http://localhost:8080" :opts {:vcr-dir "/temp"}}))))
-  (testing "Should accept https://puppetdb:8081 with a map of (dummy) certs"
-    (let [opts {:ssl-ca-cert (to-url "./dev-resources/certs/ca-cert.pem")
-                :ssl-cert    (to-url "./dev-resources/certs/cert.pem")
-                :ssl-key     (to-url "./dev-resources/certs/key.pem")
+  (testing "Should accept https://puppetdb:8081 with a map of test certs"
+    (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
+                :ssl-cert    "./dev-resources/certs/cert.pem"
+                :ssl-key     "./dev-resources/certs/key.pem"
                 :vcr-dir     nil}
           conn (connect "https://puppetdb:8081" opts)]
       ;; I'm only testing for truthiness of conn here. Schema validation should handle the rest,
       ;; and testing equality with java.io.File objects doesn't seem to work.
       (is conn)))
-  (testing "Should accept https://puppetdb:8081 with a map of (dummy) certs and VCR enabled"
-    (let [opts {:ssl-ca-cert (to-url "./dev-resources/certs/ca-cert.pem")
-                :ssl-cert    (to-url "./dev-resources/certs/cert.pem")
-                :ssl-key     (to-url "./dev-resources/certs/key.pem")
+  (testing "Should accept https://puppetdb:8081 with a map of test certs and VCR enabled"
+    (let [opts {:ssl-ca-cert "./dev-resources/certs/ca-cert.pem"
+                :ssl-cert    "./dev-resources/certs/cert.pem"
+                :ssl-key     "./dev-resources/certs/key.pem"
                 :vcr-dir     "/temp"}
           conn (connect "https://puppetdb:8081" opts)]
       ;; I'm testing for truthiness of conn here. Schema validation should handle the rest except the VCR piece,


### PR DESCRIPTION
This removes dependency on `puppetlabs/trapperkeeper-webserver-jetty9`, improves ssl-context error checking, and reverts to specifying certificates/private key files as plain strings.
